### PR TITLE
refactor: replaces Poetry usage with UV in publishing workflow and ad…

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,18 +21,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
           python-version: "3.x"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install poetry
-          poetry config ${{ secrets.PYPI_SECRET_KEY }}
-      - name: Check Package
-        run: poetry check
       - name: Build Package
-        run: poetry build
+        run: uv build
       - name: Publish Package
-        run: poetry publish
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: uv publish


### PR DESCRIPTION
…ds UV installation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the release workflow to use uv for build and publish, adding uv setup and token env while removing Poetry steps.
> 
> - **CI/Release Workflow** (`.github/workflows/python-publish.yml`):
>   - Switch build/publish from `poetry` to `uv`.
>     - Add `uv` installation via `astral-sh/setup-uv@v5`.
>     - Replace `poetry build`/`poetry publish` with `uv build` and `uv publish`.
>     - Set `UV_PUBLISH_TOKEN` from `secrets.PYPI_API_TOKEN`.
>     - Remove Poetry-specific install and package check steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62c5ee773bfc21c85c37ab9c2bc588b3c7805c63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->